### PR TITLE
replace multiple \n to <br>

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -116,7 +116,7 @@ function genMainContent(
         `<img src="${image.thumb}"/>`
       ),
     ),
-    tag("p", sanitize(post.record.text).replace(/\n/, "<br>")),
+    tag("p", sanitize(post.record.text).replace(/\n/g, "<br>")),
     (hasBskyType(post.embed, "view") &&
         hasBskyType(post.embed.record, "viewRecord"))
       ? tag(


### PR DESCRIPTION
It is assumed that the sanitize(post.record.text) would have two or more newlines, but replace(/\n/, "\<br>") would replace only the first \n appeared in the string. I'm not sure, but I expect that replace() here intended to replace all \n to \<br>.