### PR TITLE
added docker/podman deployment workflow

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,0 +1,16 @@
+FROM docker.io/denoland/deno
+
+# The port that your application listens to.
+EXPOSE 8000
+
+WORKDIR /app
+
+# Prefer not to run as root.
+USER deno
+
+# Cache the dependencies as a layer (the following two steps are re-run only when deps.ts is modified).
+# Ideally cache deps.ts will download and compile _all_ external files used in main.ts.
+COPY . .
+RUN deno cache server.ts
+
+CMD ["run", "--allow-net", "--allow-env", "--allow-read", "server.ts"]

--- a/README.md
+++ b/README.md
@@ -18,6 +18,34 @@ BLUESKY_PASSWORD=your-pass
 
 After that, run `deno task dev` to start server.
 
+## Docker/Podman Use
+You can deploy this server using Docker or Podman using the included Containerfile to build the image.  Simply...
+
+`git clone https://github.com/kawarimidoll/bluestream.git`
+
+navigate into the repo directory and 
+
+`podman build -t bluestream:latest .`
+or
+`docker build -t bluestream:latest .`
+
+create an .env file with 
+```
+BLUESKY_IDENTIFIER=your-handle
+BLUESKY_PASSWORD=your-pass
+```
+
+It is recommended you make this outside of the repo's directory so it won't get included in the container image in later builds.
+
+and run:
+`podman run -d -v /path/to/env/file/on/host/.env:/app/.env:z -p 8000:8000 bluestream:latest`
+
+or
+
+`docker run -d -v /path/to/env/file/on/host/.env:/app/.env -p 8000:8000 bluestream:latest`
+
+You should be navigate to whatever port you exposed on the host for the container to access the server.
+
 ## Author
 
 [kawarimidoll](https://bsky.app/profile/did:plc:okalufxun5rpqzdrwf5bpu3d)

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ or
 
 `docker run -d -v /path/to/env/file/on/host/.env:/app/.env -p 8000:8000 bluestream:latest`
 
-You should be navigate to whatever port you exposed on the host for the container to access the server.
+You should be able navigate to whatever port you exposed on the host for the container to access the server.
 
 ## Author
 


### PR DESCRIPTION
added Containerfile to allow building using docker/podman and instructions on the readme for how to use it to deploy the server.

I saw you didn't want to get involved with creating the whole github action ci/cd pipeline to push containers to image repos, but this will let the user build it themselves so you don't have to worry about managing and maintaining that whole process.